### PR TITLE
Add .gitattributes to fix language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.sv    linguist-language=SystemVerilog
+*.svh   linguist-language=SystemVerilog
+*.v     linguist-language=Verilog
+
+0.doc/** linguist-documentation
+*.html  linguist-documentation


### PR DESCRIPTION
Mark HDL files as SystemVerilog/Verilog and treat 0.doc and HTML as documentation so GitHub shows the correct project language instead of HTML.